### PR TITLE
Additional library that is needed for CentOS 7

### DIFF
--- a/os_specific_tasks/centos7.yaml
+++ b/os_specific_tasks/centos7.yaml
@@ -54,6 +54,7 @@
       - libtelnet
       - libtelnet-devel
       - tomcat9
+      - tomcat-native
       - policycoreutils-python
       - python2-PyMySQL
     state: present


### PR DESCRIPTION
Hi,
 Not sure about the other distros and version but for CentOS  I needed to install tomcat-native to enable secure communication. 
Note: This is only needed if you want to secure Gucac. with SSL. I think it betters prepare the solution by adding the necessary libraries from the beginning.